### PR TITLE
feat(regionSelector): match selection overlay rounding to Hyprland decoration:rounding

### DIFF
--- a/quickshell/modules/common/Appearance.qml
+++ b/quickshell/modules/common/Appearance.qml
@@ -111,7 +111,6 @@ Singleton {
         property int small: 12
         property int normal: 17
         property int large: 23
-        property int windowRounding: 18
     }
 
     property QtObject sizes: QtObject {

--- a/quickshell/modules/regionSelector/RegionSelection.qml
+++ b/quickshell/modules/regionSelector/RegionSelection.qml
@@ -336,7 +336,7 @@ PanelWindow {
                 borderColor: root.windowBorderColor
                 fillColor: root.windowFillColor
                 regionOpacity: root.targetRegionOpacity
-                radius: Appearance.rounding.windowRounding
+                radius: HyprlandData.decorationRounding
                 labelProperty: "class"
                 draggedAway: dragState.draggedAway
                 targetedRegionX: dragState.targetedRegionX
@@ -352,7 +352,7 @@ PanelWindow {
                 borderColor: root.windowBorderColor
                 fillColor: root.windowFillColor
                 regionOpacity: root.targetRegionOpacity
-                radius: Appearance.rounding.windowRounding
+                radius: HyprlandData.decorationRounding
                 labelProperty: "namespace"
                 draggedAway: dragState.draggedAway
                 targetedRegionX: dragState.targetedRegionX

--- a/quickshell/services/HyprlandData.qml
+++ b/quickshell/services/HyprlandData.qml
@@ -9,6 +9,7 @@ Singleton {
     id: root
     property var windowList: []
     property var layers: ({})
+    property int decorationRounding: 18
 
     function updateWindowList() {
         getClients.running = true;
@@ -18,9 +19,14 @@ Singleton {
         getLayers.running = true;
     }
 
+    function updateRounding() {
+        getRounding.running = true;
+    }
+
     function updateAll() {
         updateWindowList();
         updateLayers();
+        updateRounding();
     }
 
     Component.onCompleted: {
@@ -62,6 +68,24 @@ Singleton {
                 } catch (e) {
                     console.warn("[HyprlandData] Failed to parse layers JSON:", e.message);
                     root.layers = {};
+                }
+            }
+        }
+    }
+
+    // Mirror Hyprland's decoration:rounding so selection overlays match real window corners.
+    // Reads the runtime-resolved value over IPC (config-language-agnostic; survives hyprlang->Lua).
+    Process {
+        id: getRounding
+        command: ["hyprctl", "getoption", "decoration:rounding", "-j"]
+        stdout: StdioCollector {
+            id: roundingCollector
+            onStreamFinished: {
+                try {
+                    root.decorationRounding = JSON.parse(roundingCollector.text).int ?? 18;
+                } catch (e) {
+                    console.warn("[HyprlandData] Failed to parse rounding JSON:", e.message);
+                    root.decorationRounding = 18;
                 }
             }
         }


### PR DESCRIPTION
## What
Selection-overlay corners in the region selector now mirror Hyprland's live `decoration:rounding` instead of a hardcoded `18`, so they trace the real window corners.

## How
- `HyprlandData` gains a `decorationRounding` property, populated by `hyprctl getoption decoration:rounding -j` and refreshed on every Hyprland event (live).
- The window/layer overlay `radius` binds to it (raw 1:1).
- Falls back to `18` on any query failure.
- Removes the now-unused `Appearance.rounding.windowRounding`.

Reads the value over the `hyprctl` IPC socket, so it's config-language-agnostic and survives the hyprlang→Lua migration. `qmllint` clean.

Independent of the swappy branches; targets `main`.
