### PR TITLE
fix(regionSelector): save swappy-edited screenshots to hypr-lens dir

### DIFF
--- a/quickshell/modules/regionSelector/SnipCommands.qml
+++ b/quickshell/modules/regionSelector/SnipCommands.qml
@@ -84,11 +84,14 @@ Singleton {
         const cropToStdout = `${cropBase} -`;
         const cleanup = buildCleanup(screenshotPath);
 
+        // swappy -o - prints its final surface to stdout on exit (independent of swappy's
+        // Save button, which is hardwired to swappy's own save_dir). Capture that here so the
+        // result lands in hypr-lens's clipboard/save dir. Mirrors buildCopyCommand.
         if (!alsoSave) {
             return [
                 "bash", "-c",
-                `${cropToStdout} | swappy -f -; \
-                ${buildNotify("Copied to clipboard", "")}; \
+                `${cropToStdout} | swappy -f - -o - | wl-copy && \
+                { ${buildNotify("Copied to clipboard", "")}; } && \
                 ${cleanup}`
             ];
         }
@@ -97,9 +100,12 @@ Singleton {
         return [
             "bash", "-c",
             `${buildSaveSetup(expandedSaveDir)} && \
-            ${cropToStdout} | swappy -f -; \
-            wl-paste > "$savePath" && \
-            ${buildNotify("Copied & saved", "$savePath")}; \
+            ${cropToStdout} | swappy -f - -o - | tee >(wl-copy) > "$savePath" && \
+            if [ -s "$savePath" ]; then \
+                ${buildNotify("Copied & saved", "$savePath")}; \
+            else \
+                rm -f "$savePath"; ${buildNotify("Copy failed", "")}; \
+            fi && \
             ${cleanup}`
         ];
     }


### PR DESCRIPTION
## What
"Edit with swappy" now routes edited screenshots into hypr-lens's own save dir / clipboard instead of swappy's default `~/Desktop`.

## Why
swappy's Save button only writes to swappy's global `save_dir` (default `~/Desktop`), disconnected from hypr-lens. Diagnosed in the investigation: the file *was* saving — just not where users expected it.

## How
Capture swappy's final surface via `swappy -f - -o -` (stdout on exit) and route it through hypr-lens's own clipboard/disk handling, mirroring `buildCopyCommand`. Respects `copyAlsoSaves` (clipboard always; disk only when enabled). Removes the fragile `wl-paste` hack and cleans up empty files on failed saves. `qmllint` clean.

> **Note:** `fix/swappy-escape-discard` builds on this branch and evolves `buildEditCommand` further (Save = keep / Escape = discard). The two are sequential — this is the intermediate step.
